### PR TITLE
Update dependencies to allow ovos-utils 0.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,4 @@
-ovos-plugin-manager~=0.0.21
-ovos-utils~=0.0.30
+ovos-plugin-manager~=0.0.24
+ovos-utils~=0.0,>=0.0.30
 streaming-stt-nemo~=0.2
 SpeechRecognition~=3.8
-
-# TODO: Patching OPM
-mycroft-messagebus-client~=0.10


### PR DESCRIPTION
# Description
Also removes `mycroft-messagebus-client` dependency patching previous bug in `ovos-plugin-manager`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->