### PR TITLE
Update OPM dependency to allow latest stable version

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -35,8 +35,8 @@ jobs:
         run: |
           pytest tests/test_stt.py --junitxml=tests/stt-test-results.xml
       - name: Upload STT test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: pytest-results-3.7
+          name: pytest-results-${{ matrix.python-version }}
           path: tests/stt-test-results.xml
         if: ${{ always() }}

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-ovos-plugin-manager~=0.0.24
+ovos-plugin-manager~=0.0,>=0.0.24
 ovos-utils~=0.0,>=0.0.30
 streaming-stt-nemo~=0.2,>=0.2.1a0
 SpeechRecognition~=3.8


### PR DESCRIPTION
# Description
Updates dependencies to allow resolution of ovos-plugin-manager>=0.1.0
Resolve deprecated artifact upload in unit tests
Include Python3.10 unit tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->