### PR TITLE
Pin ovos-stt-http-server dependency to resolve Gradio deployment bug

### DIFF
--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,1 +1,2 @@
-ovos-stt-http-server~=0.0.2
+ovos-stt-http-server==0.0.2
+# TODO: Gradio broken in 0.0.3+ with fix in https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/28


### PR DESCRIPTION
# Description
Pin `ovos-stt-http-server` to resolve broken container with a comment linking the PR for a future fix


# Issues
https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/28 should enable updating dependencies here to 0.1.4+

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->